### PR TITLE
[RFR] Update dockerfile to run as non-root user for OCP deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ FROM ruby:2.6
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
 
-WORKDIR /usr/src/app
+# allow this container to run as non-root user
+RUN adduser --disabled-password fixture-bot && adduser fixture-bot root
+WORKDIR /home/fixture-bot
+RUN chmod -R 775 /home/fixture-bot && chown -R fixture-bot:root /home/fixture-bot
 
 # install ruby dependencies and Python
 COPY Gemfile Gemfile.lock ./
@@ -11,7 +14,10 @@ RUN gem install bundler && bundle install && apt-get update && apt-get install p
 # install python dependencies (integration_tests and its venv)
 RUN git clone https://github.com/ManageIQ/integration_tests.git && cd integration_tests && pip3 --no-cache-dir install -r requirements/frozen.py3.txt
 
-COPY fixture_bot.rb /usr/src/app/fixture_bot.rb
+COPY fixture_bot.rb /home/fixture-bot/fixture_bot.rb
+
+# Specify user
+USER 1000
 
 # run the ruby script
-CMD /usr/src/app/fixture_bot.rb
+CMD /home/fixture-bot/fixture_bot.rb


### PR DESCRIPTION
Running as root is not necessary for this container, and causes the container to break on OCP. 