### PR TITLE
[RFR] Use sed for fixture determination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,9 @@ build/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# ignore non-template data file
+conf/fixture_bot.yaml
+
+# swap file
+*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,9 @@ RUN adduser --disabled-password fixture-bot && adduser fixture-bot root
 WORKDIR /home/fixture-bot
 RUN chmod -R 775 /home/fixture-bot && chown -R fixture-bot:root /home/fixture-bot
 
-# install ruby dependencies and Python
+# install ruby dependencies
 COPY Gemfile Gemfile.lock ./
-RUN gem install bundler && bundle install && apt-get update && apt-get install python3 python3-pip git -y && apt-get clean
-# install python dependencies (integration_tests and its venv)
-RUN git clone https://github.com/ManageIQ/integration_tests.git && cd integration_tests && pip3 --no-cache-dir install -r requirements/frozen.py3.txt
+RUN gem install bundler && bundle install 
 
 COPY fixture_bot.rb /home/fixture-bot/fixture_bot.rb
 


### PR DESCRIPTION
Major rework of how fixtures are determined. Rather than trying to locate them in the `diff`, which turned out to be very unreliable, we now clone the PR branch, get the line number changed, and use `sed` to search for the parent function back 100 lines from that changed line. 

We then look for `@pytest.fixture` in the line above the function definition. 

This has the advantage of _much_ faster than trying to import all the fixtures, in addition to getting rid of the need for an `integration_tests` python env. 

In addition, the `grep` used to determine where the fixtures are used now looks for an exact match. The fixture bot will also no longer report on global fixtures that have been overwritten by local fixtures. (e.g. there is a global fixture `template`, but there are also many test modules that define their own local fixture `template` we don't want to report on those local cases if the global fixture is modified. 

Still need to figure out how to deal with functions that are nested in fixtures. 